### PR TITLE
Fix wnnm with ref clip and update NOISY preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ denoise = BM3DCuda.denoise(
     clip, sigma=0.8, tr=2, profile=Profile.NORMAL, ref=ref, planes=0
 )
 
-denoise = nl_means(denoise, tr=2, strength=0.6, ref=ref, planes=[1, 2])
+denoise = nl_means(denoise, tr=2, strength=0.2, ref=ref, planes=[1, 2])
 ```

--- a/vsdenoise/blockmatch.py
+++ b/vsdenoise/blockmatch.py
@@ -118,7 +118,7 @@ def wnnm(
     elif ref is not None:
         ref = depth(ref, 32)
         ref = get_y(ref) if func.luma_only else ref
-        check_ref_clip(clip, ref, func.func)
+        check_ref_clip(func.work_clip, ref, func.func)
 
     return func.return_clip(
         _recursive_denoise(

--- a/vsdenoise/mvtools/presets.py
+++ b/vsdenoise/mvtools/presets.py
@@ -141,7 +141,7 @@ class MVToolsPresets:
     """Fast preset"""
 
     NOISY = MVToolsPreset(
-        pel=2, thSAD=100, block_size=32, overlap=property(fget=lambda x: x.block_size // 2),
+        pel=2, thSAD=100, block_size=16, overlap=property(fget=lambda x: x.block_size // 2),
         motion=MotionMode.HIGH_SAD, prefilter=Prefilter.DFTTEST,
         sad_mode=(SADMode.ADAPTIVE_SPATIAL_MIXED, SADMode.ADAPTIVE_SATD_MIXED)
     )


### PR DESCRIPTION
When passing a 16 bit clip to wnnm with a ref clip, it will currently throw a FormatsRefClipMismatchError as it compares the 16 bit input clip to the converted 32 bit ref. I fixed that by having it compare the 32 bit work clip to the ref.

As for the NOISY preset, a block_size of 16 and overlap of 8 can lead to more desirable results and it doesn't make sense to use the same values from the FAST preset.

Finally, I adjusted the nlmeans strength in the example readme as the value is way too high for the default wmode.