### PR TITLE
MVTools: Fix degrain limit being wrongly scaled

### DIFF
--- a/vsdenoise/mvtools/mvtools.py
+++ b/vsdenoise/mvtools/mvtools.py
@@ -714,7 +714,7 @@ class MVTools:
                 '"limit" values should be between 0 and 255 (inclusive)!', self.degrain
             )
 
-        limitf, limitCf = scale_value(limit, 8, ref), scale_value(limitC, 8, ref)
+        limitf, limitCf = scale_value(limit, 8, ref, ColorRange.FULL), scale_value(limitC, 8, ref, ColorRange.FULL)
 
         thSCD1, thSCD2 = self.normalize_thscd(thSCD, thSAD, self.degrain)
 


### PR DESCRIPTION
When passing a integer clip, the mvtools plugin silently clamps it I guess, but if the clip is float mvtools is just crashing without any error message.