### PR TITLE
Fix TRT selection in dpir

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,12 @@ jobs:
           - "3.11"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -27,5 +28,5 @@ jobs:
       - name: Running flake8
         run: flake8 vsdenoise
       - name: Running mypy
-        if: steps.dependencies.outcome == 'success'
         run: mypy vsdenoise
+        continue-on-error: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 flake8>=4.0.1
-mypy>=0.961
-mypy-extensions>=0.4.3
+mypy>=1.9.0
+mypy-extensions>=1.0.0

--- a/vsdenoise/deblock.py
+++ b/vsdenoise/deblock.py
@@ -239,13 +239,11 @@ class _dpir(CustomStrEnum):
         bkwargs = kwargs | KwargsT(fp16=fp16, device_id=device_id)
 
         # All this will eventually be in vs-nn
-        if cuda is None or trt_available:
+        if cuda == 'trt':
             try:
                 data: KwargsT = core.trt.DeviceProperties(device_id)  # type: ignore
                 memory = data.get('total_global_memory', 0)
                 def_num_streams = data.get('async_engine_count', 1)
-
-                cuda = 'trt'
 
                 bkwargs = KwargsT(
                     workspace=memory / (1 << 22) if memory else None,


### PR DESCRIPTION
The `cuda is None` check is useless because `cuda` is always defined by line 73 after the 0b3a10546183dbec946aa1d5e434e13729b727c9 refactor (this is caught by mypy). So what actually ends up happening is that the TRT backend is always chosen if it's supported by the current system, even if the user explicitly wants another backend.

Before:

```python
dpir(clip)
# backend = Backend.TRT

dpir(clip, cuda=False)
# backend = Backend.TRT

dpir(clip, cuda=True)
# backend = Backend.TRT

dpir(clip, cuda="trt")
# backend = Backend.TRT
```

After:

```python
dpir(clip)
# backend = Backend.TRT

dpir(clip, cuda=False)
# backend = Backend.NCNN_VK

dpir(clip, cuda=True)
# backend = Backend.ORT_CUDA

dpir(clip, cuda="trt")
# backend = Backend.TRT
```
